### PR TITLE
Use nipy_spectral colormap

### DIFF
--- a/writeData.py
+++ b/writeData.py
@@ -35,7 +35,7 @@ def drawGraphic(data, figure, xLabel = None, yLabel = None, title = None, logPlo
         norm = None
         
     subplot = figure.add_subplot(111)
-    pic = subplot.imshow(data, norm=norm, aspect="auto", cmap=cm.spectral, extent=extent)
+    pic = subplot.imshow(data, norm=norm, aspect="auto", cmap=cm.nipy_spectral, extent=extent)
 
     if xLabel:
         plt.xlabel(xLabel, fontsize=20)


### PR DESCRIPTION
cm.spectral was renamed a while ago to cm.nipy_spectral with
a deprecation warning, and the original name was later removed. This
makes the writeData script work with current matplotlib versions. It
should also be compatible with older releases, as the nipy_spectral
alias was created in version 1.3, released in 2013.